### PR TITLE
Fix proguard file directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You're all set, enjoy!
 
 4. Finally add this line to your proguard file:
 ```kotlin
--keep class com.github.aachartmodel.aainfographics.** { *; }
+-keep class com.github.aachartmodel.aainfographics.* { *; }
 ```
 
 🌹🌹🌹Congratulations! Everything was done!!! You will get what you want!!!


### PR DESCRIPTION
```
-keep class com.github.aachartmodel.aainfographics.** { *; } 
```
throws unresolved class error with Android Studio 4, changing to ** -> * fixes this issue.