### PR TITLE
Change to correct proguard rule for release builds to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You're all set, enjoy!
 
 4. Finally add this line to your proguard file:
 ```kotlin
--keep class com.github.aachartmodel.aainfographics.* { *; }
+-keep class com.github.aachartmodel.aainfographics.** { *; }
 ```
 
 🌹🌹🌹Congratulations! Everything was done!!! You will get what you want!!!


### PR DESCRIPTION
I noticed that the charts were not appearing with the original proguard config in my release app. I updated and this solved the issue for me