### PR TITLE
Add a Builder for AAChartModel 

### DIFF
--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAChartModel.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAChartModel.kt
@@ -28,6 +28,8 @@
 
 package com.github.aachartmodel.aainfographics.aachartcreator
 
+import android.content.Context
+import android.os.Build
 import com.github.aachartmodel.aainfographics.aaoptionsmodel.AAScrollablePlotArea
 import com.github.aachartmodel.aainfographics.aaoptionsmodel.AAStyle
 
@@ -155,55 +157,98 @@ enum class AAChartFontWeightType(val value: String) {
     Bold("bold"),
 }
 
-
-class AAChartModel {
-
-    var animationType: AAChartAnimationType? = null //动画类型
-    var animationDuration: Int? = null         //动画时间
-    var title: String? = null                  //标题内容
-    var titleStyle: AAStyle? = null            //标题文本风格样式
-    var subtitle: String? = null               //副标题内容
-    var subtitleAlign: AAChartAlignType? = null
-    var subtitleStyle: AAStyle? = null         //副标题文本风格样式
-    var axesTextColor: String? = null          //x 轴和 y 轴文字颜色
-    var chartType: AAChartType? = null         //图表类型
-    var stacking: AAChartStackingType? = null  //堆积样式
-    var markerRadius: Float? = null            //折线连接点的半径长度
-    var markerSymbol: AAChartSymbolType? =
-        null//折线曲线连接点的类型："circle", "square", "diamond", "triangle","triangle-down"，默认是"circle"
-    var markerSymbolStyle: AAChartSymbolStyleType? = null
-    var zoomType: AAChartZoomType? = null      //缩放类型 AAChartZoomTypeX表示可沿着 x 轴进行手势缩放
-    var inverted: Boolean? = null              //x 轴是否翻转(垂直)
-    var xAxisReversed: Boolean? = null         //x 轴翻转
-    var yAxisReversed: Boolean? = null         //y 轴翻转
-    var tooltipEnabled: Boolean? = null        //是否显示浮动提示框(默认显示)
-    var tooltipValueSuffix: String? = null     //浮动提示框单位后缀
-    var gradientColorEnable: Boolean? = null   //是否要为渐变色
-    var polar: Boolean? = null                 //是否极化图形(变为雷达图)
-    var margin: Array<Float>? = null           //图表外边缘和绘图区域之间的边距
-    var dataLabelsEnabled: Boolean? = null     //是否显示数据
-    var dataLabelsStyle: AAStyle? = null
-    var xAxisLabelsEnabled: Boolean? = null    //x轴是否显示数据
-    var xAxisTickInterval: Int? = null
-    var categories: Array<String>? = null      //x轴是否显示数据
-    var xAxisGridLineWidth: Float? = null      //x轴网格线的宽度
-    var xAxisVisible: Boolean? = null          //x 轴是否显示
-    var yAxisVisible: Boolean? = null          //y 轴是否显示
-    var yAxisLabelsEnabled: Boolean? = null    //y轴是否显示数据
-    var yAxisTitle: String? = null             //y轴标题
-    var yAxisLineWidth: Float? = null          //y 轴轴线的宽度
-    var yAxisMin: Float? = null
-    var yAxisMax: Float? = null
-    var yAxisAllowDecimals: Boolean? = null
-    var yAxisGridLineWidth: Float? = null      //y轴网格线的宽度
-    var colorsTheme: Array<Any>? = null        //图表主题颜色数组
-    var legendEnabled: Boolean? = null         //是否显示图例
-    var backgroundColor: Any? = null          //图表背景色
-    var borderRadius: Float? = null            //柱状图长条图头部圆角半径(可用于设置头部的形状,仅对条形图,柱状图有效)
-    var series: Array<AASeriesElement>? = null
-    var touchEventEnabled: Boolean? = null     //是否支持用户触摸事件
+/**
+ * @param animationType 动画类型
+ * @param animationDuration 动画时间
+ * @param title 标题内容
+ * @param titleStyle 标题文本风格样式
+ * @param subtitle 副标题内容
+ * @param subtitleAlign
+ * @param subtitleStyle 副标题文本风格样式
+ * @param axesTextColor x 轴和 y 轴文字颜色
+ * @param chartType 图表类型
+ * @param stacking 堆积样式
+ * @param markerRadius 折线连接点的半径长度,如果值设置为0,这样就相当于不显示了
+ * @param markerSymbol 折线曲线连接点的类型："circle", "square", "diamond", "triangle","triangle-down"，默认是"circle"
+ * @param markerSymbolStyle
+ * @param zoomType 缩放类型 AAChartZoomTypeX表示可沿着 x 轴进行手势缩放
+ * @param inverted x 轴是否翻转(垂直)
+ * @param xAxisReversed x 轴翻转
+ * @param yAxisReversed y 轴翻转
+ * @param tooltipEnabled 是否显示浮动提示框(默认显示)
+ * @param tooltipValueSuffix 浮动提示框单位后缀
+ * @param gradientColorEnable 是否要为渐变色
+ * @param polar 是否极化图形(变为雷达图)
+ * @param margin 图表外边缘和绘图区域之间的边距
+ * @param dataLabelsEnabled 是否显示数据
+ * @param dataLabelsStyle
+ * @param xAxisLabelsEnabled x轴是否显示数据
+ * @param xAxisTickInterval
+ * @param categories x轴是否显示数据
+ * @param xAxisGridLineWidth x轴网格线的宽度
+ * @param xAxisVisible x 轴是否显示
+ * @param yAxisVisible y 轴是否显示
+ * @param yAxisLabelsEnabled y轴是否显示数据
+ * @param yAxisTitle y轴标题
+ * @param yAxisLineWidth y 轴轴线的宽度
+ * @param yAxisMin
+ * @param yAxisMax
+ * @param yAxisAllowDecimals
+ * @param yAxisGridLineWidth y轴网格线的宽度
+ * @param colorsTheme 图表主题颜色数组
+ * @param legendEnabled 是否显示图例
+ * @param backgroundColor 图表背景色
+ * @param borderRadius 柱状图长条图头部圆角半径(可用于设置头部的形状,仅对条形图,柱状图有效,设置为1000时,柱形图或者条形图头部为楔形)
+ * @param series
+ * @param touchEventEnabled 是否支持用户触摸事件
+ * @param scrollablePlotArea
+ */
+class AAChartModel(
+    var animationType: AAChartAnimationType? = AAChartAnimationType.Linear,
+    var animationDuration: Int? = 500,
+    var title: String? = "",
+    var titleStyle: AAStyle? = null,
+    var subtitle: String? = "",
+    var subtitleAlign: AAChartAlignType? = null,
+    var subtitleStyle: AAStyle? = null,
+    var axesTextColor: String? = null,
+    var chartType: AAChartType? = AAChartType.Line,
+    var stacking: AAChartStackingType? = AAChartStackingType.False,
+    var markerRadius: Float? = 6f,
+    var markerSymbol: AAChartSymbolType? = null,
+    var markerSymbolStyle: AAChartSymbolStyleType? = AAChartSymbolStyleType.Normal,
+    var zoomType: AAChartZoomType? = AAChartZoomType.None,
+    var inverted: Boolean? = false,
+    var xAxisReversed: Boolean? = false,
+    var yAxisReversed: Boolean? = false,
+    var tooltipEnabled: Boolean? = null,
+    var tooltipValueSuffix: String? = null,
+    var gradientColorEnable: Boolean? = false,
+    var polar: Boolean? = false,
+    var margin: Array<Float>? = null,
+    var dataLabelsEnabled: Boolean? = false,
+    var dataLabelsStyle: AAStyle? = null,
+    var xAxisLabelsEnabled: Boolean? = true,
+    var xAxisTickInterval: Int? = null,
+    var categories: Array<String>? = null,
+    var xAxisGridLineWidth: Float? = 0f,
+    var xAxisVisible: Boolean? = null,
+    var yAxisVisible: Boolean? = null,
+    var yAxisLabelsEnabled: Boolean? = true,
+    var yAxisTitle: String? = null,
+    var yAxisLineWidth: Float? = null,
+    var yAxisMin: Float? = null,
+    var yAxisMax: Float? = null,
+    var yAxisAllowDecimals: Boolean? = null,
+    var yAxisGridLineWidth: Float? = 1f,
+    var colorsTheme: Array<Any>? = arrayOf("#fe117c", "#ffc069", "#06caf4", "#7dffc0"),
+    var legendEnabled: Boolean? = true,
+    var backgroundColor: Any? = "#ffffff",
+    var borderRadius: Float? = 0f,
+    var series: Array<AASeriesElement>? = null,
+    var touchEventEnabled: Boolean? = null,
     var scrollablePlotArea: AAScrollablePlotArea? = null
-
+) {
 
     fun animationType(prop: AAChartAnimationType): AAChartModel {
         animationType = prop
@@ -405,7 +450,6 @@ class AAChartModel {
         return this
     }
 
-
     fun borderRadius(prop: Float?): AAChartModel {
         borderRadius = prop
         return this
@@ -426,30 +470,458 @@ class AAChartModel {
         return this
     }
 
-    init {
-        title = ""
-        subtitle = ""
-        chartType = AAChartType.Line
-        animationDuration = 500 //以毫秒为单位
-        animationType = AAChartAnimationType.Linear
-        inverted = false
-        stacking = AAChartStackingType.False
-        xAxisReversed = false
-        yAxisReversed = false
-        zoomType = AAChartZoomType.None
-        dataLabelsEnabled = false
-        markerSymbolStyle = AAChartSymbolStyleType.Normal
-        colorsTheme = arrayOf("#fe117c", "#ffc069", "#06caf4", "#7dffc0")
-        gradientColorEnable = false
-        polar = false
-        xAxisLabelsEnabled = true
-        xAxisGridLineWidth = 0f
-        yAxisLabelsEnabled = true
-        yAxisGridLineWidth = 1f
-        legendEnabled = true
-        backgroundColor = "#ffffff"
-        borderRadius = 0f//柱状图长条图头部圆角半径(可用于设置头部的形状,仅对条形图,柱状图有效,设置为1000时,柱形图或者条形图头部为楔形)
-        markerRadius = 6f//折线连接点的半径长度,如果值设置为0,这样就相当于不显示了
+    /**
+     * This Builder can help you set strings and dimensions from application resources. It enforces
+     * stricter typing than AAChartModel to prevent you from setting invalid values.
+     */
+    class Builder(context: Context) {
+        private val applicationContext = context.applicationContext
+        private val resources = applicationContext.resources
+
+        private var animationType: AAChartAnimationType? = AAChartAnimationType.Linear
+        private var animationDuration: Int? = 500
+        private var title: String? = ""
+        private var titleStyle: AAStyle? = null
+        private var subtitle: String? = ""
+        private var subtitleAlign: AAChartAlignType? = null
+        private var subtitleStyle: AAStyle? = null
+        private var axesTextColor: String? = null
+        private var chartType: AAChartType? = AAChartType.Line
+        private var stacking: AAChartStackingType? = AAChartStackingType.False
+        private var markerRadius: Float? = 6f
+        private var markerSymbol: AAChartSymbolType? = null
+        private var markerSymbolStyle: AAChartSymbolStyleType? = AAChartSymbolStyleType.Normal
+        private var zoomType: AAChartZoomType? = AAChartZoomType.None
+        private var inverted: Boolean? = false
+        private var xAxisReversed: Boolean? = false
+        private var yAxisReversed: Boolean? = false
+        private var tooltipEnabled: Boolean? = null
+        private var tooltipValueSuffix: String? = null
+        private var gradientColorEnable: Boolean? = false
+        private var polar: Boolean? = false
+        private var margin: Array<Float>? = null
+        private var dataLabelsEnabled: Boolean? = false
+        private var dataLabelsStyle: AAStyle? = null
+        private var xAxisLabelsEnabled: Boolean? = true
+        private var xAxisTickInterval: Int? = null
+        private var categories: Array<String>? = null
+        private var xAxisGridLineWidth: Float? = 0f
+        private var xAxisVisible: Boolean? = null
+        private var yAxisVisible: Boolean? = null
+        private var yAxisLabelsEnabled: Boolean? = true
+        private var yAxisTitle: String? = null
+        private var yAxisLineWidth: Float? = null
+        private var yAxisMin: Float? = null
+        private var yAxisMax: Float? = null
+        private var yAxisAllowDecimals: Boolean? = null
+        private var yAxisGridLineWidth: Float? = 1f
+        private var colorsTheme: Array<Any>? = arrayOf("#fe117c", "#ffc069", "#06caf4", "#7dffc0")
+        private var legendEnabled: Boolean? = true
+        private var backgroundColor: Any? = "#ffffff"
+        private var borderRadius: Float? = 0f
+        private var series: Array<AASeriesElement>? = null
+        private var touchEventEnabled: Boolean? = null
+        private var scrollablePlotArea: AAScrollablePlotArea? = null
+
+        constructor(context: Context, source: AAChartModel) : this(context) {
+            set(source)
+        }
+
+        private fun getString(id: Int, vararg formatArgs: Any?): String =
+            resources.getString(id, formatArgs)
+
+        private fun getColor(colorResId: Int): Int {
+            return if (Build.VERSION.SDK_INT >= 23) {
+                applicationContext.getColor(colorResId)
+            } else {
+                resources.getColor(colorResId)
+            }
+        }
+
+        private fun Int.toColorString() = String.format("#%06X", 0xFFFFFF and this)
+
+        private fun getDimen(dimenResId: Int): Float {
+            return resources.getDimension(dimenResId)
+        }
+
+        fun set(prop: AAChartModel): Builder {
+            animationType = prop.animationType
+            animationDuration = prop.animationDuration
+            title = prop.title
+            titleStyle = prop.titleStyle
+            subtitle = prop.subtitle
+            subtitleAlign = prop.subtitleAlign
+            subtitleStyle = prop.subtitleStyle
+            axesTextColor = prop.axesTextColor
+            chartType = prop.chartType
+            stacking = prop.stacking
+            markerRadius = prop.markerRadius
+            markerSymbol = prop.markerSymbol
+            markerSymbolStyle = prop.markerSymbolStyle
+            zoomType = prop.zoomType
+            inverted = prop.inverted
+            xAxisReversed = prop.xAxisReversed
+            yAxisReversed = prop.yAxisReversed
+            tooltipEnabled = prop.tooltipEnabled
+            tooltipValueSuffix = prop.tooltipValueSuffix
+            gradientColorEnable = prop.gradientColorEnable
+            polar = prop.polar
+            margin = prop.margin
+            dataLabelsEnabled = prop.dataLabelsEnabled
+            dataLabelsStyle = prop.dataLabelsStyle
+            xAxisLabelsEnabled = prop.xAxisLabelsEnabled
+            xAxisTickInterval = prop.xAxisTickInterval
+            categories = prop.categories
+            xAxisGridLineWidth = prop.xAxisGridLineWidth
+            xAxisVisible = prop.xAxisVisible
+            yAxisVisible = prop.yAxisVisible
+            yAxisLabelsEnabled = prop.yAxisLabelsEnabled
+            yAxisTitle = prop.yAxisTitle
+            yAxisLineWidth = prop.yAxisLineWidth
+            yAxisMin = prop.yAxisMin
+            yAxisMax = prop.yAxisMax
+            yAxisAllowDecimals = prop.yAxisAllowDecimals
+            yAxisGridLineWidth = prop.yAxisGridLineWidth
+            colorsTheme = prop.colorsTheme
+            legendEnabled = prop.legendEnabled
+            backgroundColor = prop.backgroundColor
+            borderRadius = prop.borderRadius
+            series = prop.series
+            touchEventEnabled = prop.touchEventEnabled
+            scrollablePlotArea = prop.scrollablePlotArea
+            return this
+        }
+
+        fun setAnimationType(prop: AAChartAnimationType): Builder {
+            animationType = prop
+            return this
+        }
+
+        fun setAnimationDuration(prop: Int): Builder {
+            animationDuration = prop
+            return this
+        }
+
+        fun setTitle(prop: String): Builder {
+            title = prop
+            return this
+        }
+
+        fun setTitle(id: Int, vararg formatArgs: Any?): Builder =
+            setTitle(getString(id, formatArgs))
+
+        fun setTitleStyle(prop: AAStyle): Builder {
+            titleStyle = prop
+            return this
+        }
+
+        fun setSubtitle(prop: String): Builder {
+            subtitle = prop
+            return this
+        }
+
+        fun setSubtitle(id: Int, vararg formatArgs: Any?): Builder =
+            setSubtitle(getString(id, formatArgs))
+
+        fun setSubtitleAlign(prop: AAChartAlignType): Builder {
+            subtitleAlign = prop
+            return this
+        }
+
+        fun setSubtitleStyle(prop: AAStyle): Builder {
+            subtitleStyle = prop
+            return this
+        }
+
+        fun setAxesTextColor(prop: String): Builder {
+            axesTextColor = prop
+            return this
+        }
+
+        fun setAxesTextColor(color: Int): Builder = setAxesTextColor(color.toColorString())
+
+        fun setAxesTextColorRes(colorResId: Int): Builder =
+            setAxesTextColor(getColor(colorResId).toColorString())
+
+        fun setChartType(prop: AAChartType): Builder {
+            chartType = prop
+            return this
+        }
+
+        fun setStacking(prop: AAChartStackingType): Builder {
+            stacking = prop
+            return this
+        }
+
+        fun setMarkerRadius(prop: Float): Builder {
+            markerRadius = prop
+            return this
+        }
+
+        fun setMarkerRadiusRes(dimenResId: Int): Builder = setMarkerRadius(getDimen(dimenResId))
+
+        fun setMarkerSymbol(prop: AAChartSymbolType): Builder {
+            markerSymbol = prop
+            return this
+        }
+
+        fun setMarkerSymbolStyle(prop: AAChartSymbolStyleType): Builder {
+            markerSymbolStyle = prop
+            return this
+        }
+
+        fun setZoomType(prop: AAChartZoomType): Builder {
+            zoomType = prop
+            return this
+        }
+
+        fun setInverted(prop: Boolean): Builder {
+            inverted = prop
+            return this
+        }
+
+        fun setXAxisReversed(prop: Boolean): Builder {
+            xAxisReversed = prop
+            return this
+        }
+
+        fun setYAxisReversed(prop: Boolean): Builder {
+            yAxisReversed = prop
+            return this
+        }
+
+        fun setTooltipEnabled(prop: Boolean): Builder {
+            tooltipEnabled = prop
+            return this
+        }
+
+        fun setTooltipValueSuffix(prop: String): Builder {
+            tooltipValueSuffix = prop
+            return this
+        }
+
+        fun setTooltipValueSuffix(stringResId: Int, vararg formatArgs: Any?): Builder =
+            setTooltipValueSuffix(getString(stringResId, formatArgs))
+
+        fun setGradientColorEnable(prop: Boolean): Builder {
+            gradientColorEnable = prop
+            return this
+        }
+
+        fun setPolar(prop: Boolean): Builder {
+            polar = prop
+            return this
+        }
+
+        fun setMargin(vararg prop: Float): Builder {
+            margin = prop.map { it }.toTypedArray()
+            return this
+        }
+
+        fun setMargin(top: Float, left: Float, bottom: Float, right: Float): Builder =
+            setMargin(top, left, bottom, right)
+
+        fun setMargin(topResId: Int, leftResId: Int, bottomResId: Int, rightResId: Int): Builder =
+            setMargin(
+                getDimen(topResId),
+                getDimen(leftResId),
+                getDimen(bottomResId),
+                getDimen(rightResId)
+            )
+
+        fun setDataLabelsEnabled(prop: Boolean): Builder {
+            dataLabelsEnabled = prop
+            return this
+        }
+
+        fun setDataLabelsStyle(prop: AAStyle): Builder {
+            dataLabelsStyle = prop
+            return this
+        }
+
+        fun setXAxisLabelsEnabled(prop: Boolean): Builder {
+            xAxisLabelsEnabled = prop
+            return this
+        }
+
+        fun setXAxisTickInterval(prop: Int): Builder {
+            xAxisTickInterval = prop
+            return this
+        }
+
+        fun setCategories(vararg prop: String): Builder {
+            categories = prop.map { it }.toTypedArray()
+            return this
+        }
+
+        /** Set Category labels, supports StringRes IDs */
+        fun setCategories(vararg stringResIds: Int): Builder =
+            setCategories(*stringResIds.map { stringResId -> getString(stringResId) }
+                .toTypedArray())
+
+        fun setXAxisGridLineWidth(prop: Float): Builder {
+            xAxisGridLineWidth = prop
+            return this
+        }
+
+        fun setXAxisGridLineWidth(dimenResId: Int): Builder =
+            setXAxisGridLineWidth(getDimen(dimenResId))
+
+        fun setYAxisGridLineWidth(prop: Float): Builder {
+            yAxisGridLineWidth = prop
+            return this
+        }
+
+        fun setYAxisGridLineWidth(dimenResId: Int): Builder =
+            setYAxisGridLineWidth(getDimen(dimenResId))
+
+        fun setXAxisVisible(prop: Boolean): Builder {
+            xAxisVisible = prop
+            return this
+        }
+
+        fun setYAxisVisible(prop: Boolean): Builder {
+            yAxisVisible = prop
+            return this
+        }
+
+        fun setYAxisLabelsEnabled(prop: Boolean): Builder {
+            yAxisLabelsEnabled = prop
+            return this
+        }
+
+        fun setYAxisTitle(prop: String): Builder {
+            yAxisTitle = prop
+            return this
+        }
+
+        fun setYAxisTitle(stringResId: Int, vararg formatArgs: Any?): Builder =
+            setYAxisTitle(getString(stringResId, formatArgs))
+
+        fun setYAxisLineWidth(prop: Float): Builder {
+            yAxisLineWidth = prop
+            return this
+        }
+
+        fun setYAxisLineWidth(dimenResId: Int): Builder =
+            setYAxisLineWidth(getDimen(dimenResId))
+
+        fun setYAxisMin(prop: Float?): Builder {
+            yAxisMin = prop
+            return this
+        }
+
+        fun setYAxisMin(dimenResId: Int): Builder =
+            setYAxisMin(getDimen(dimenResId))
+
+        fun setYAxisMax(prop: Float?): Builder {
+            yAxisMax = prop
+            return this
+        }
+
+        fun setYAxisMax(dimenResId: Int): Builder =
+            setYAxisMax(getDimen(dimenResId))
+
+        fun setYAxisAllowDecimals(prop: Boolean): Builder {
+            yAxisAllowDecimals = prop
+            return this
+        }
+
+        fun setColorsTheme(prop: Array<Any>): Builder {
+            colorsTheme = prop.map { it }.toTypedArray()
+            return this
+        }
+
+        fun setColorsTheme(vararg prop: String): Builder {
+            colorsTheme = prop.map { it }.toTypedArray()
+            return this
+        }
+
+        /** Set theme colors, supports ColorRes IDs */
+        fun setColorsTheme(vararg colorResIds: Int): Builder =
+            setColorsTheme(*colorResIds.map { getColor(it).toColorString() }.toTypedArray())
+
+        fun setLegendEnabled(prop: Boolean): Builder {
+            legendEnabled = prop
+            return this
+        }
+
+        fun setBackgroundColor(prop: String): Builder {
+            backgroundColor = prop
+            return this
+        }
+
+        fun setBackgroundColor(colorResId: Int): Builder =
+            setBackgroundColor(getColor(colorResId).toColorString())
+
+        fun setBorderRadius(prop: Float): Builder {
+            borderRadius = prop
+            return this
+        }
+
+        fun setBorderRadius(dimenResId: Int): Builder = setBorderRadius(getDimen(dimenResId))
+
+        fun setSeries(vararg prop: AASeriesElement): Builder {
+            series = prop.map { it }.toTypedArray()
+            return this
+        }
+
+        fun setTouchEventEnabled(prop: Boolean): Builder {
+            touchEventEnabled = prop
+            return this
+        }
+
+        fun setScrollablePlotArea(prop: AAScrollablePlotArea): Builder {
+            scrollablePlotArea = prop
+            return this
+        }
+
+        fun build(): AAChartModel = AAChartModel(
+            animationType = animationType,
+            animationDuration = animationDuration,
+            title = title,
+            titleStyle = titleStyle,
+            subtitle = subtitle,
+            subtitleAlign = subtitleAlign,
+            subtitleStyle = subtitleStyle,
+            axesTextColor = axesTextColor,
+            chartType = chartType,
+            stacking = stacking,
+            markerRadius = markerRadius,
+            markerSymbol = markerSymbol,
+            markerSymbolStyle = markerSymbolStyle,
+            zoomType = zoomType,
+            inverted = inverted,
+            xAxisReversed = xAxisReversed,
+            yAxisReversed = yAxisReversed,
+            tooltipEnabled = tooltipEnabled,
+            tooltipValueSuffix = tooltipValueSuffix,
+            gradientColorEnable = gradientColorEnable,
+            polar = polar,
+            margin = margin,
+            dataLabelsEnabled = dataLabelsEnabled,
+            dataLabelsStyle = dataLabelsStyle,
+            xAxisLabelsEnabled = xAxisLabelsEnabled,
+            xAxisTickInterval = xAxisTickInterval,
+            categories = categories,
+            xAxisGridLineWidth = xAxisGridLineWidth,
+            xAxisVisible = xAxisVisible,
+            yAxisVisible = yAxisVisible,
+            yAxisLabelsEnabled = yAxisLabelsEnabled,
+            yAxisTitle = yAxisTitle,
+            yAxisLineWidth = yAxisLineWidth,
+            yAxisMin = yAxisMin,
+            yAxisMax = yAxisMax,
+            yAxisAllowDecimals = yAxisAllowDecimals,
+            yAxisGridLineWidth = yAxisGridLineWidth,
+            colorsTheme = colorsTheme,
+            legendEnabled = legendEnabled,
+            backgroundColor = backgroundColor,
+            borderRadius = borderRadius,
+            series = series,
+            touchEventEnabled = touchEventEnabled,
+            scrollablePlotArea = scrollablePlotArea,
+        )
     }
 }
 

--- a/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/DoubleChartsLinkedWorkActivity.kt
+++ b/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/DoubleChartsLinkedWorkActivity.kt
@@ -83,45 +83,45 @@ class DoubleChartsLinkedWorkActivity : AppCompatActivity(),
                 AAGradientColor.BerrySmoothie
         )
         gradientColorsArr = gradientColorArr as Array<Any>
-        val aaChartModel: AAChartModel = AAChartModel()
-            .chartType(AAChartType.Column)
-            .title("")
-            .yAxisTitle("")
-            .categories(gradientColorNamesArr)
-            .colorsTheme(gradientColorArr as Array<Any>)
-            .xAxisReversed(true)
-            .yAxisReversed(true)
-            .inverted(true)
-            .legendEnabled(false)
-            .touchEventEnabled(true)
-            .series(arrayOf(
+        val aaChartModel: AAChartModel = AAChartModel.Builder(this)
+            .setChartType(AAChartType.Column)
+            .setTitle("")
+            .setYAxisTitle("")
+            .setCategories(*gradientColorNamesArr)
+            .setColorsTheme(gradientColorArr)
+            .setXAxisReversed(true)
+            .setYAxisReversed(true)
+            .setInverted(true)
+            .setLegendEnabled(false)
+            .setTouchEventEnabled(true)
+            .setSeries(
                     AASeriesElement()
                         .name("Tokyo")
                         .data(arrayOf(
                                 211, 183, 157, 133, 111, 91, 73, 57, 43, 31, 21, 13,
                                 211, 183, 157, 133, 111, 91, 73, 57, 43, 31, 21, 13
                             ))
-                        .colorByPoint(true)))
+                        .colorByPoint(true)).build()
         val aaOptions: AAOptions = aaChartModel.aa_toAAOptions()
         aaOptions.plotOptions?.column?.groupPadding = 0f
         return aaOptions
     }
 
     private fun configureChartOptions2(): AAOptions {
-        val aaChartModel: AAChartModel = AAChartModel()
-            .chartType(AAChartType.Column)
-            .title("")
-            .yAxisTitle("")
-            .legendEnabled(false)
-            .yAxisGridLineWidth(0f)
-            .series(arrayOf(
+        val aaChartModel: AAChartModel = AAChartModel.Builder(this)
+            .setChartType(AAChartType.Column)
+            .setTitle("")
+            .setYAxisTitle("")
+            .setLegendEnabled(false)
+            .setYAxisGridLineWidth(0f)
+            .setSeries(
                     AASeriesElement()
                         .name("Tokyo")
                         .data(arrayOf(
                                 211,183,157,133,111,91,73,57,43,31,21,13,
                                 211,183,157,133,111,91,73,57,43,31,21,13,
                             ))
-            ))
+            ).build()
         val aaOptions: AAOptions = aaChartModel.aa_toAAOptions()
         aaOptions.plotOptions?.column?.groupPadding = 0f
         return aaOptions

--- a/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/OnlyRefreshChartDataActivity.kt
+++ b/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/OnlyRefreshChartDataActivity.kt
@@ -79,19 +79,20 @@ class OnlyRefreshChartDataActivity : AppCompatActivity() {
     private fun configureChartBasicContent(): AAChartModel {
         val intent = intent
         val chartType = intent.getStringExtra("chartType")
-        return AAChartModel()
-            .chartType(convertStringToEnum(chartType!!))
-            .xAxisVisible(true)
-            .yAxisVisible(false)
-            .title("")
-            .yAxisTitle("摄氏度")
-            .colorsTheme(arrayOf(
+        return AAChartModel.Builder(this)
+            .setChartType(convertStringToEnum(chartType!!))
+            .setXAxisVisible(true)
+            .setYAxisVisible(false)
+            .setTitle("")
+            .setYAxisTitle("摄氏度")
+            .setColorsTheme(arrayOf(
                     AAGradientColor.Sanguine,
                     AAGradientColor.DeepSea,
                     AAGradientColor.NeonGlow,
                     AAGradientColor.WroughtIron
                 ))
-            .stacking(AAChartStackingType.Normal)
+            .setStacking(AAChartStackingType.Normal)
+            .build()
     }
 
     private fun convertStringToEnum(chartTypeStr: String): AAChartType {

--- a/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/ScrollableChartActivity.kt
+++ b/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/ScrollableChartActivity.kt
@@ -31,21 +31,22 @@ class ScrollableChartActivity : AppCompatActivity() {
 
         val seriesDataArray = configureSeriesDataArray() as Array<Any>
 
-        val aaChartModel = AAChartModel()
-            .chartType(chartTypeEnum)
-            .title("")
-            .yAxisTitle("")
-            .legendEnabled(false)
-            .yAxisGridLineWidth(0f)
-            .scrollablePlotArea(
+        val aaChartModel = AAChartModel.Builder(this)
+            .setChartType(chartTypeEnum)
+            .setTitle("")
+            .setYAxisTitle("")
+            .setLegendEnabled(false)
+            .setYAxisGridLineWidth(0f)
+            .setScrollablePlotArea(
                 AAScrollablePlotArea()
                     .minWidth(3000)
                     .scrollPositionX(1f))
-            .series(arrayOf(
+            .setSeries(
                     AASeriesElement()
                         .name("Tokyo")
                         .data(seriesDataArray)
-                ))
+                )
+            .build()
 
         this.aaChartModel = aaChartModel
         configureTheStyleForDifferentTypeChart(chartTypeEnum, position)

--- a/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/basiccontent/CommonChartActivity.kt
+++ b/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/basiccontent/CommonChartActivity.kt
@@ -72,14 +72,14 @@ class CommonChartActivity : AppCompatActivity(), RadioGroup.OnCheckedChangeListe
         val position = intent.getIntExtra("position", 0)
         val chartTypeEnum = convertStringToEnum(chartType)
 
-       val aaChartModel = AAChartModel()
-                .chartType(chartTypeEnum)
-                .backgroundColor("#4b2b7f")
-                .dataLabelsEnabled(false)
-                .yAxisGridLineWidth(0f)
-                .legendEnabled(false)
-                .touchEventEnabled(true)
-                .series(arrayOf(
+       val aaChartModel = AAChartModel.Builder(this)
+                .setChartType(chartTypeEnum)
+                .setBackgroundColor("#4b2b7f")
+                .setDataLabelsEnabled(false)
+                .setYAxisGridLineWidth(0f)
+                .setLegendEnabled(false)
+                .setTouchEventEnabled(true)
+                .setSeries(
                         AASeriesElement()
                                 .name("Tokyo")
                                 .data(arrayOf(7.0, 6.9, 9.5, 14.5, 18.2, 21.5, 25.2, 26.5, 23.3, 18.3, 13.9, 9.6)),
@@ -92,7 +92,8 @@ class CommonChartActivity : AppCompatActivity(), RadioGroup.OnCheckedChangeListe
                         AASeriesElement()
                                 .name("Berlin")
                                 .data(arrayOf(3.9, 4.2, 5.7, 8.5, 11.9, 15.2, 17.0, 16.6, 14.2, 10.3, 6.6, 4.8))
-                ))
+                )
+           .build()
 
         configureTheStyleForDifferentTypeChart(chartType,position)
 


### PR DESCRIPTION
In my project I'm getting Chart titles, colors and dimensions from resources (never hard-coded values). This Builder would help clean up my code so I can just specify a string/color/dimen resource ID instead of extracting it in my own code and setting it on `AAChartModel`.

I also passed in the wrong type for `backgroundColor `when I first  started using this lib, which didn't occur to me at first. The Builder is a bit more strict on types you can set for each field, but it's 100% compatible with `AAChartModel `so it won't break any current application.

The Builder class only holds on to the applicationContext, so users can somewhat safely hold on to a reference of the builder to create new `AAChartModel`s OR they can create a new `Builder `from a `AAChartModel` using the copy constructor or the setter.

I'm not exactly sure what the possible (allowed) types are for the `Any `and `Nullable `fields in `AAChartModel` but I tried making the Builder a bit stricter than `AAChartModel`. This can be improved later on and in the mean time, `AAChartModel` is still mutable and can be updated as before. All in all, this Builder is just an extension of `AAChartModel` to help keep users code tidier 😃 