### PR TITLE
fix error shows in scrollable chart

### DIFF
--- a/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/ScrollableChartActivity.kt
+++ b/sample/src/main/java/com/github/aachartmodel/aainfographics/demo/additionalcontent/ScrollableChartActivity.kt
@@ -71,7 +71,7 @@ class ScrollableChartActivity : AppCompatActivity() {
         position: Int
     ) {
         if ((chartType == AAChartType.Area || chartType == AAChartType.Line)
-            && (position == 93 || position == 94)
+            && (position == 4 || position == 5)
         ) {
             configureStepAreaChartAndStepLineChart()
         } else if (chartType == AAChartType.Column || chartType == AAChartType.Bar) {


### PR DESCRIPTION
fix error shows in scrollable chart, include `Step Area Chart` and `Step Line Chart`

修复可滚动图标中的错误跳转问题，包括 `直方折线填充图` 和 `直方折线图` 