### PR TITLE
修改了X轴和Y轴的属性类为open

### DIFF
--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAXAxis.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAXAxis.kt
@@ -9,7 +9,7 @@
 package com.github.aachartmodel.aainfographics.aaoptionsmodel
 
 
-class AAXAxis: AAAxis() {
+open class AAXAxis: AAAxis() {
     fun allowDecimals(prop: Boolean?): AAXAxis {
         allowDecimals = prop
         return this

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAYAxis.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAYAxis.kt
@@ -8,7 +8,7 @@
  */
 package com.github.aachartmodel.aainfographics.aaoptionsmodel
 
-class AAYAxis: AAAxis() {
+open class AAYAxis: AAAxis() {
     var stackLabels: Any? = null
     fun stackLabels(prop: Any?): AAYAxis {
         stackLabels = prop


### PR DESCRIPTION
修改了X轴和Y轴的属性类为open,方便在不修改源码的情况下,开发者可自行参考[hcharts](https://www.hcharts.cn/)的api文档来添加库中不支持的属性