### PR TITLE
Add chart.zooming and related option builders

### DIFF
--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAChartModel.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAChartModel.kt
@@ -31,6 +31,7 @@ package com.github.aachartmodel.aainfographics.aachartcreator
 import android.content.Context
 import com.github.aachartmodel.aainfographics.aaoptionsmodel.AAScrollablePlotArea
 import com.github.aachartmodel.aainfographics.aaoptionsmodel.AAStyle
+import com.github.aachartmodel.aainfographics.aaoptionsmodel.AAZooming
 import com.github.aachartmodel.aainfographics.aatools.AABuilder
 
 enum class AAChartAnimationType(val value: String) {
@@ -249,7 +250,8 @@ class AAChartModel(
     var series: Array<Any>? = null,
     var clickEventEnabled: Boolean? = null,
     var touchEventEnabled: Boolean? = null,
-    var scrollablePlotArea: AAScrollablePlotArea? = null
+    var scrollablePlotArea: AAScrollablePlotArea? = null,
+    var zooming: AAZooming? = null
 ) {
 
     fun animationType(prop: AAChartAnimationType): AAChartModel {
@@ -474,6 +476,11 @@ class AAChartModel(
 
     fun scrollablePlotArea(prop: AAScrollablePlotArea): AAChartModel {
         scrollablePlotArea = prop
+        return this
+    }
+
+    fun zooming(prop: AAZooming?): AAChartModel {
+        zooming = prop
         return this
     }
 

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAChartView.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAChartView.kt
@@ -239,7 +239,7 @@ class AAChartView : WebView {
 
             //convert fist character to be lowercase string
             val firstChar = classNameStr.substring(0, 1)
-            val lowercaseFirstStr = firstChar.toLowerCase(Locale.ROOT)
+            val lowercaseFirstStr = firstChar.lowercase(Locale.ROOT)
             classNameStr = classNameStr.substring(1)
             val finalClassName = lowercaseFirstStr + classNameStr
             val finalOptionsMap = HashMap<String, Any>()

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAOptions.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aachartcreator/AAOptions.kt
@@ -172,11 +172,16 @@ object AAOptionsConstructor {
             .type(aaChartModel.chartType) //绘图类型
             .inverted(aaChartModel.inverted) //设置是否反转坐标轴，使X轴垂直，Y轴水平。 如果值为 true，则 x 轴默认是 倒置 的。 如果图表中出现条形图系列，则会自动反转
             .backgroundColor(aaChartModel.backgroundColor) //设置图表的背景色(包含透明度的设置)
-            .pinchType(aaChartModel.zoomType) //设置手势缩放方向
             .panning(true) //设置手势缩放后是否可平移
             .polar(aaChartModel.polar) //是否极化图表(开启极坐标模式)
             .margin(aaChartModel.margin)
             .scrollablePlotArea(aaChartModel.scrollablePlotArea)
+
+        if (aaChartModel.zooming == null) {
+            aaChart.pinchType(aaChartModel.zoomType) //设置手势缩放方向
+        } else {
+            aaChart.zooming(aaChartModel.zooming) //设置手势缩放方向
+        }
 
         val aaTitle = AATitle()
             .text(aaChartModel.title) //标题文本内容

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAAxis.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAAxis.kt
@@ -56,4 +56,5 @@ enum class AAChartAxisType(val value: String) {
     var tickLength: Number? = null //坐标轴刻度线的长度。 默认是：10.
     var tickPosition: String? = null //刻度线相对于轴线的位置，可用的值有 inside 和 outside，分别表示在轴线的内部和外部。 默认是：outside.
     var tickPositions: Array<Any>? = null // Custom chart axis coordinates
+    var tickAmount: Int? = null //The amount of ticks to draw on the axis.
 }

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAButtonTheme.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAButtonTheme.kt
@@ -1,0 +1,16 @@
+package com.github.aachartmodel.aainfographics.aaoptionsmodel
+
+class AAButtonTheme {
+    var fill: String? = null
+    var stroke: String? = null
+    var radius: Int? = null
+    var style: Map<String, Any>? = null
+
+    fun fill(fill: String?) = apply { this.fill = fill }
+
+    fun stroke(stroke: String?) = apply { this.stroke = stroke }
+
+    fun radius(radius: Int?) = apply { this.radius = radius }
+
+    fun style(style: Map<String, Any>?) = apply { this.style = style }
+}

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAChart.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAChart.kt
@@ -35,6 +35,7 @@ class AAChart {
     var zoomType: String? = null
     var events: AAChartEvents? = null
     var height: Number? = null
+    var zooming: AAZooming? = null
     
 
     fun type(prop: AAChartType?): AAChart {
@@ -129,6 +130,11 @@ class AAChart {
 
     fun height(height: Number?): AAChart {
         this.height = height
+        return this
+    }
+
+    fun zooming(zooming: AAZooming?): AAChart {
+        this.zooming = zooming
         return this
     }
 

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAMouseWheelOptions.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAMouseWheelOptions.kt
@@ -1,0 +1,11 @@
+package com.github.aachartmodel.aainfographics.aaoptionsmodel
+
+class AAMouseWheelOptions {
+    var enabled: Boolean? = null
+    var sensitivity: Float? = null
+    var type: String? = null  // "x" | "y" | "xy"
+
+    fun enabled(v: Boolean?) = apply { enabled = v }
+    fun sensitivity(v: Float?) = apply { sensitivity = v }
+    fun type(v: String?) = apply { type = v }
+}

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAResetButtonOptions.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAResetButtonOptions.kt
@@ -1,0 +1,10 @@
+package com.github.aachartmodel.aainfographics.aaoptionsmodel
+
+class AAResetZoomButtonOptions {
+    var theme: AAButtonTheme? = null
+    var position: AAPosition? = null // align/verticalAlign/x/y
+
+    fun theme(theme: AAButtonTheme?) = apply { this.theme = theme }
+
+    fun position(position: AAPosition?) = apply { this.position = position }
+}

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAStyle.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAStyle.kt
@@ -35,6 +35,7 @@ class AAStyle {
     var transition: String? = null
     var whiteSpace: String? = null
     var width: Number? = null
+    var zIndex: Number? = null
 
 
     fun background(prop: String?): AAStyle {
@@ -155,6 +156,11 @@ class AAStyle {
 
     fun width(prop: Number?): AAStyle {
         width = prop
+        return this
+    }
+
+    fun zIndex(prop: Number?): AAStyle {
+        zIndex = prop
         return this
     }
 

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AATooltip.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AATooltip.kt
@@ -61,6 +61,7 @@ class AATooltip {
     var pointFormatter: String? = null
     var positioner: String? = null
     var dateTimeLabelFormats: AADateTimeLabelFormats? = null
+    var outside: Boolean? = null
 
     fun animation(prop: AAAnimation): AATooltip {
         animation = prop
@@ -177,6 +178,11 @@ class AATooltip {
         return this
     }
 
+    fun outside(prop: Boolean?): AATooltip {
+        outside = prop
+        return this
+    }
+
     init {
         shared = true
         enabled = true
@@ -184,6 +190,5 @@ class AATooltip {
     }
 
 }
-
 
 

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAYAxis.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAYAxis.kt
@@ -256,4 +256,9 @@ open class AAYAxis: AAAxis() {
         return this
     }
 
+    fun tickAmount(prop: Int?): AAYAxis {
+        tickAmount = prop
+        return this
+    }
+
 }

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAZooming.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aaoptionsmodel/AAZooming.kt
@@ -1,0 +1,22 @@
+package com.github.aachartmodel.aainfographics.aaoptionsmodel
+
+class AAZooming {
+    var type: String? = null // "x" | "y" | "xy"
+    var pinchType: String? = null // "x" | "y" | "xy" (multitouch)
+    var singleTouch: Boolean? = null // true = one-finger zoom (since HC 10.2)
+    var key: String? = null // "shift" | "alt" | "ctrl" | "meta"
+    var resetButton: AAResetZoomButtonOptions? = null
+    var mouseWheel: AAMouseWheelOptions? = null
+
+    fun type(type: String?) = apply { this.type = type }
+
+    fun pinchType(pinchType: String?) = apply { this.pinchType = pinchType }
+
+    fun singleTouch(singleTouch: Boolean?) = apply { this.singleTouch = singleTouch }
+
+    fun key(key: String?) = apply { this.key = key }
+
+    fun resetButton(resetButton: AAResetZoomButtonOptions?) = apply { this.resetButton = resetButton }
+
+    fun mouseWheel(mouseWheel: AAMouseWheelOptions?) = apply { this.mouseWheel = mouseWheel }
+}

--- a/charts/src/main/java/com/github/aachartmodel/aainfographics/aatools/AAGradientColor.kt
+++ b/charts/src/main/java/com/github/aachartmodel/aainfographics/aatools/AAGradientColor.kt
@@ -275,8 +275,8 @@ object AAGradientColor {
             endColor: String
     ): Map<String, Any> {
         return linearGradient(direction, arrayOf<Any>(
-                arrayOf(0, startColor),
-                arrayOf(1, endColor)
+                arrayOf<Any>(0, startColor),
+                arrayOf<Any>(1, endColor)
         ))
     }
 


### PR DESCRIPTION
## Summary

This PR adds typed/fluent Kotlin models for newer Highcharts chart configuration options:

- adds AAZooming and wires it through AAChartModel, AAChart, and AAOptionsConstructor
- preserves the existing zoomType -> pinchType behavior when AAZooming is not set
- adds nested zooming option models for mouse wheel, reset button, and button theme configuration
- adds fluent options for tooltip.outside, style.zIndex, and yAxis.tickAmount
- updates two Kotlin expressions for newer compiler compatibility

## Why

Highcharts supports richer zoom configuration through chart.zooming, including options such as pinchType, singleTouch, mouseWheel, resetButton, and modifier-key behavior.

The existing model only exposes the simpler pinchType path through AAChartModel.zoomType, which makes the richer chart.zooming object unavailable through the library's typed/fluent Kotlin API.

This keeps chart configuration in the existing model style while preserving backward compatibility.

## Compatibility

Existing AAChartModel.zoomType(...) calls continue to serialize as chart.pinchType when .zooming(...) is not set.

The new .zooming(...) API only changes output when callers explicitly provide an AAZooming instance.

All new option fields are nullable, so unset values are omitted by the existing Gson serialization behavior.